### PR TITLE
Increase courseItem size on FrontPage

### DIFF
--- a/src/components/CourseList/CourseItem.scss
+++ b/src/components/CourseList/CourseItem.scss
@@ -7,7 +7,7 @@
   align-content: flex-start;
   flex-direction: column;
   align-items: center;
-  max-width: 150px;
+  max-width: 175px;
   &:hover {
     color: inherit;
     text-decoration: none;
@@ -22,15 +22,21 @@
 .courseLogo {
   max-width: 100%;
   padding: 5px;
-  height: 120px;
+  height: 170px;
   margin-bottom: 15px;
 }
 
+@media screen and (max-width: 500px) {
+  .courseLogo {
+    height: 140px;
+  }
+}
+
 .courseName {
-  font-size: 1.3em;
+  font-size: 1.4em;
 }
 
 .lessonCount {
-  font-size: 0.9em;
+  font-size: 1em;
   color: $color-gray;
 }

--- a/src/components/CourseList/CourseList.js
+++ b/src/components/CourseList/CourseList.js
@@ -1,8 +1,10 @@
 import React, {PropTypes} from 'react';
+import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import styles from './CourseList.scss';
 import CourseItem from './CourseItem';
+
 import Col from 'react-bootstrap/lib/Col';
 import Row from 'react-bootstrap/lib/Row';
-
 
 const CourseList = React.createClass({
   sortCourses(a, b) {
@@ -15,11 +17,13 @@ const CourseList = React.createClass({
 
     return (
       <Row>
-        {courseNames.map((courseName, idx) => (
-          <Col key={idx} xs={6} sm={4} md={3} lg={2}>
-            <CourseItem course={courses[courseName]}/>
-          </Col>
-        ))}
+        <div className={styles.courseList}>
+          {courseNames.map((courseName, idx) => (
+            <Col key={idx} xs={6} sm={6} md={4} lg={3}>
+              <CourseItem course={courses[courseName]}/>
+            </Col>
+          ))}
+        </div>
       </Row>
     );
   }
@@ -29,4 +33,4 @@ CourseList.propTypes = {
   courses: PropTypes.object
 };
 
-export default CourseList;
+export default withStyles(styles)(CourseList);

--- a/src/components/CourseList/CourseList.scss
+++ b/src/components/CourseList/CourseList.scss
@@ -1,0 +1,3 @@
+.courseList {
+  max-width: 900px;
+}

--- a/src/components/FrontPage/Courses.js
+++ b/src/components/FrontPage/Courses.js
@@ -10,7 +10,7 @@ export const Courses = React.createClass({
 
   render() {
     return (
-      <Col xs={12} sm={8} md={9} lg={10}>
+      <Col xs={12} sm={8} md={9} lg={8} lgOffset={1}>
         <Row>
           <Col xs={12}>
             <h2>Kurs</h2>

--- a/src/pages/FrontPage.js
+++ b/src/pages/FrontPage.js
@@ -42,6 +42,8 @@ export const  FrontPage = React.createClass({
           <TeacherInfobox isStudentMode={this.props.isStudentMode}/>
         </Row>
 
+        <hr/>
+
         {/* Filter and courses */}
         <Row>
           <Filter/>


### PR DESCRIPTION
Gjøre ikoner og tekst til kursene større på forsiden.
Kurslisten bruker ikke hele bredden på store skjermer.